### PR TITLE
Fixed timers problem, better synchronization in AudioStream

### DIFF
--- a/libecho/src/AudioFormatFactory.h
+++ b/libecho/src/AudioFormatFactory.h
@@ -3,6 +3,9 @@
 
 #include <QtMultimedia/QAudioFormat>
 
+/**
+ * @brief Class to create QAudioFormat instances with predefined settings.
+ */
 class AudioFormatFactory {
 public:
     /**

--- a/libecho/src/AudioInput.h
+++ b/libecho/src/AudioInput.h
@@ -5,10 +5,13 @@
 
 #include <QtMultimedia/QAudioInput>
 
+/**
+ * @brief AudioStream with QAudioInput as internal stream.
+ */
 class AudioInput : public AudioStream<QAudioInput> {
 public:
     /**
-     * @brief Constructs AudioInput object - AudioStream with QAudioInput as internal stream.
+     * @brief Constructs AudioInput object.
      * @param format    Parameters for stream, passed to QAudioOutput.
      */
     explicit AudioInput(const QAudioFormat &format);

--- a/libecho/src/AudioOutput.h
+++ b/libecho/src/AudioOutput.h
@@ -6,6 +6,9 @@
 #include <QtMultimedia/QAudioFormat>
 #include <QtMultimedia/QAudioOutput>
 
+/**
+ * @brief AudioStream with QAudioOutput as internal stream.
+ */
 class AudioOutput : public AudioStream<QAudioOutput> {
 public:
     /**

--- a/libecho/src/AudioOutput.h
+++ b/libecho/src/AudioOutput.h
@@ -33,6 +33,7 @@ private:
 
     /**
      * @brief Temporary buffer to allow pushing more data than normal buffer allows.
+     *
      * Data from it will be pushed to normal buffer on every notify() signal and after calling enqueueData.
      */
     QByteArray buffer{};

--- a/libecho/src/AudioStream.h
+++ b/libecho/src/AudioStream.h
@@ -46,6 +46,10 @@ protected slots:
      * See also: https://doc.qt.io/qt-5/qaudiooutput.html#setNotifyInterval
      */
     virtual void handleNotify_slot() = 0;
+
+    virtual void startStream_slot() = 0;
+
+    virtual void stopStream_slot() = 0;
 };
 
 /**
@@ -76,10 +80,12 @@ public:
      * @param format    Format that will be used by stream.
      */
     explicit AudioStream(const QAudioFormat &format) : format(format) {
+        std::unique_lock<std::mutex> lock(mutex);
         qDebug() << "Constructing AudioStream. Thread:" << QThread::thread();
         this->moveToThread(this);
         QThread::start();
-        waitForTick_NT();
+
+        sync.wait(lock);
     }
 
     /**
@@ -93,6 +99,34 @@ public:
         this->quit();
         this->wait();
         delete qStream;
+    }
+
+    /**
+    * @brief Starts the underlying QT audio stream.
+    * The implementation doesn't currently support stopping and restarting stream,because of problems with QMetaObject.
+    * Doing so results in console errors.
+    */
+    void startStream() {
+        std::unique_lock<std::mutex> lock(mutex);
+
+        bool success = QMetaObject().invokeMethod(this, "startStream_slot");
+        qDebug() << "Calling startStream:" << (success ? "success" : "failed");
+
+        sync.wait(lock);
+    }
+
+    /**
+     * @brief Stops the underlying QT audio stream.
+     * The implementation doesn't currently support stopping and restarting audio stream. Doing so results in console
+     * errors.
+     */
+    void stopStream() {
+        std::unique_lock<std::mutex> lock(mutex);
+
+        bool success = QMetaObject().invokeMethod(this, "stopStream_slot");
+        qDebug() << "Calling startStream:" << (success ? "success" : "failed");
+
+        sync.wait(lock);
     }
 
     /**
@@ -165,36 +199,12 @@ protected:
      */
     std::mutex mutex{};
 
-    /**
-     * @brief Starts the underlying QT audio stream.
-     * The implementation doesn't currently support stopping and restarting stream,because of problems with QMetaObject.
-     * Doing so results in console errors.
-     */
-    void startStream() {
-        qDebug() << "Starting stream from thread" << thread();
-        qDevice = qStream->start();
-        auto info = getStreamInfo();
-        qDebug("\tBuffer size: %d\n\tPeriod size: %d\n\tNotify interval: %d\n\tVolume: %lf\n\t", info.bufferSize,
-               info.periodSize, info.notifyInterval, info.volume);
-        forTick.notify_all();
-    }
-
-    /**
-     * @brief Stops the underlying QT audio stream.
-     * The implementation doesn't currently support stopping and restarting audio stream. Doing so results in console
-     * errors.
-     */
-    void stopStream() {
-        qDebug() << "Stopping stream from thread" << thread();
-        qStream->stop();
-        qDevice = nullptr;
-    }
-
 private:
     QAudioFormat format{};
 
     std::condition_variable forTick{};
     std::condition_variable forState{};
+    std::condition_variable sync{};
 
     /**
      * @brief Executed by QThread when starting it. Initializes and starts qStream.
@@ -202,6 +212,8 @@ private:
      * lifetime of object.
      */
     void run() override {
+        std::unique_lock<std::mutex> lock(mutex);
+
         qDebug() << "Running thread " << thread();
 
         qStream = new StreamType(format, this);
@@ -209,7 +221,8 @@ private:
         connect(qStream, &StreamType::stateChanged, this, &AudioStream<StreamType>::handleStateChanged_slot);
         connect(qStream, &StreamType::notify, this, &AudioStream<StreamType>::handleNotify_slot);
 
-        startStream();
+        lock.unlock();
+        sync.notify_all();
         QThread::exec();
     }
 
@@ -229,6 +242,30 @@ private:
         qDebug() << "State changed signal received. New state: " << newState;
         forState.notify_all();
     };
+
+    void startStream_slot() override {
+        std::unique_lock<std::mutex> lock(mutex);
+
+        qDebug() << "Starting stream from thread" << thread();
+        qDevice = qStream->start();
+        auto info = getStreamInfo();
+        qDebug("\tBuffer size: %d\n\tPeriod size: %d\n\tNotify interval: %d\n\tVolume: %lf\n\t", info.bufferSize,
+               info.periodSize, info.notifyInterval, info.volume);
+
+        lock.unlock();
+        sync.notify_all();
+    }
+
+    void stopStream_slot() override {
+        std::unique_lock<std::mutex> lock(mutex);
+
+        qDebug() << "Stopping stream from thread" << thread();
+        qStream->stop();
+        qDevice = nullptr;
+
+        lock.unlock();
+        sync.notify_all();
+    }
 };
 
 #endif  // ECHOCONNECT_AUDIOSTREAM_H

--- a/libecho/src/AudioStream.h
+++ b/libecho/src/AudioStream.h
@@ -24,6 +24,7 @@ struct AudioStreamInfo {
 
 /**
  * @brief Helper class for AudioStream<StreamType>.
+ *
  * It is needed because Q_OBJECT macro doesn't support template classes.
  * One way to solve it is to move signals/slots to base, non-template class,
  * and override those methods in derived class (without using signals/slots keywords again).
@@ -33,6 +34,7 @@ class AudioStreamSignalsAndSlots : public QThread {
 protected slots:
     /**
      * @brief Slot called very time stream status changes.
+     *
      * QAudio::State: https://doc.qt.io/qt-5/qaudio.html#State-enum
      * According to QT docs (https://doc.qt.io/qt-5/qaudiooutput.html), not all states are possible here:
      * "At any given time, the QAudioOutput will be in one of four states: active, suspended, stopped, or idle."
@@ -42,6 +44,7 @@ protected slots:
 
     /**
      * @brief Slot called once in a configurable amount of time.
+     *
      * It's based on amount of sound data processed, not real time.
      * See also: https://doc.qt.io/qt-5/qaudiooutput.html#setNotifyInterval
      */
@@ -62,6 +65,7 @@ class AudioStream : public AudioStreamSignalsAndSlots {
 public:
     /**
      * @brief Status of stream.
+     *
      * First element is available bytes in buffer (free buffer for output, available bytes in buffer for input).
      * Output: https://doc.qt.io/qt-5/qaudiooutput.html#bytesFree
      * Input: https://doc.qt.io/qt-5/qaudioinput.html#bytesReady
@@ -75,8 +79,9 @@ public:
 
     /**
      * @brief Constructors for AudioStream.
+     *
      * Initializes members of class. Starts QThread which will process stream's signals.
-     * Starts stream. Returns after thread and stream are started,
+     * Returns after thread is started,
      * @param format    Format that will be used by stream.
      */
     explicit AudioStream(const QAudioFormat &format) : format(format) {
@@ -90,8 +95,8 @@ public:
 
     /**
      * @brief Destroys AudioStream.
+     *
      * Stops stream. Kills QThread and waits for it to end.
-     * Currently produces console errors because of stopping timers from wrong thread.
      */
     ~AudioStream() override {
         qDebug() << "Destroying AudioStream";
@@ -103,8 +108,6 @@ public:
 
     /**
     * @brief Starts the underlying QT audio stream.
-    * The implementation doesn't currently support stopping and restarting stream,because of problems with QMetaObject.
-    * Doing so results in console errors.
     */
     void startStream() {
         std::unique_lock<std::mutex> lock(mutex);
@@ -117,8 +120,6 @@ public:
 
     /**
      * @brief Stops the underlying QT audio stream.
-     * The implementation doesn't currently support stopping and restarting audio stream. Doing so results in console
-     * errors.
      */
     void stopStream() {
         std::unique_lock<std::mutex> lock(mutex);
@@ -147,6 +148,7 @@ public:
 
     /**
      * @brief Waits for qStream to be in given state.
+     *
      * Returns immmediately if qStream is already in desired state.
      * Else returns after stateChanged(new_state) slot with desired state is called.
      * @param waitFor   State we are waiting for.
@@ -161,6 +163,7 @@ public:
 
     /**
      * @brief Returns current stream information.
+     *
      * Meaning of certain fields is explained in AudioStreamInfo docs.
      * @return  Struct with current informations about stream.
      */
@@ -208,6 +211,7 @@ private:
 
     /**
      * @brief Executed by QThread when starting it. Initializes and starts qStream.
+     *
      * Currently the implementation doesn't support stopping and restarting the thread - it is alive for the whole
      * lifetime of object.
      */

--- a/libecho/src/AudioStream.h
+++ b/libecho/src/AudioStream.h
@@ -247,6 +247,11 @@ private:
         forState.notify_all();
     };
 
+    /**
+     * @brief Starts underlying StreamType object (by calling start method on it).
+     *
+     * As any other slot, should only be called from thread that owns this object.
+     */
     void startStream_slot() override {
         std::unique_lock<std::mutex> lock(mutex);
 
@@ -260,6 +265,11 @@ private:
         sync.notify_all();
     }
 
+    /**
+     * @brief Stops underlying StreamType object (by calling stop method on it).
+     *
+     * As any other slot, should only be called from thread that owns this object.
+     */
     void stopStream_slot() override {
         std::unique_lock<std::mutex> lock(mutex);
 

--- a/libecho/src/AudioStream.h
+++ b/libecho/src/AudioStream.h
@@ -107,8 +107,8 @@ public:
     }
 
     /**
-    * @brief Starts the underlying QT audio stream.
-    */
+     * @brief Starts the underlying QT audio stream.
+     */
     void startStream() {
         std::unique_lock<std::mutex> lock(mutex);
 

--- a/libecho/src/Echo.cc
+++ b/libecho/src/Echo.cc
@@ -31,6 +31,7 @@ void Echo::send(const std::vector<uint8_t> &buffer) {
     auto encoded = converter->encode(buffer);
     const size_t atOnce = 2600;  // (bitrate / notify_interval) + eps; - TODO: wyjaśnić
 
+    output->startStream();
     output->enqueueData(encoded.data(), std::min(encoded.size(), atOnce));
     for (int i = atOnce; i < encoded.size(); i += atOnce) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
@@ -41,6 +42,7 @@ void Echo::send(const std::vector<uint8_t> &buffer) {
     }
 
     output->waitForState(QAudio::State::IdleState);
+    output->stopStream();
 }
 
 static double dft(const char *buffer, int samples, int sampleSize, double ratio) {
@@ -92,6 +94,7 @@ std::vector<uint8_t> Echo::receive() {
     double loMag;
     double hiMag;
 
+    input->startStream();
     clearInput();
 
     qDebug() << "Listening for" << loFreq << "/" << hiFreq << "Hz";
@@ -120,6 +123,8 @@ std::vector<uint8_t> Echo::receive() {
         res_bits.push_back(loMag < hiMag);
         getbuff(bytes, buffer.data());
     }
+
+    input->stopStream();
 
     // pad the bit vector with zeroes
     while (res_bits.size() % CHAR_BIT != 0) {

--- a/libecho/src/QTInitializer.h
+++ b/libecho/src/QTInitializer.h
@@ -3,6 +3,9 @@
 
 #include <QtCore/QCoreApplication>
 
+/**
+ * @brief Helper class to initialize QApplication, if it hasn't already been initialized.
+ */
 class QTInitializer {
 public:
     /**

--- a/libecho/tests/tmp_test.cpp
+++ b/libecho/tests/tmp_test.cpp
@@ -20,8 +20,7 @@ TEST(test_receive, tmp_test) {
     for (uint8_t u : rec) {
         if (32 < u && u < 127) {
             putchar(u);
-        }
-        else {
+        } else {
             printf("<%hhu>", u);
         }
     }


### PR DESCRIPTION
- Fixed errors while destroying AudioStream
- Added startStream() and stopStream() methods to AudioStream. 
- Stream is not started by default. Before doing IO you must start it with startStream(). After finishing your work you should stop it with stopStream().
- Better synchronization in AudioStream: now it should work in all scenarios,