### PR TITLE
multiplatform CI

### DIFF
--- a/.github/workflows/CI-lint.yml
+++ b/.github/workflows/CI-lint.yml
@@ -34,7 +34,7 @@ jobs:
         cached: ${{ steps.cache-deps.outputs.cache-hit }}
 
     - name: Install PulseAudio, Doxygen
-        run: sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
+        run: sudo apt-get install libpulse-dev clang-tidy-9
 
     - name: Check code formatting with clang-format
       uses: DoozyX/clang-format-lint-action@v0.5

--- a/.github/workflows/CI-lint.yml
+++ b/.github/workflows/CI-lint.yml
@@ -34,7 +34,7 @@ jobs:
         cached: ${{ steps.cache-deps.outputs.cache-hit }}
 
     - name: Install PulseAudio, Doxygen
-        run: sudo apt-get install libpulse-dev clang-tidy-9
+      run: sudo apt-get install libpulse-dev clang-tidy-9
 
     - name: Check code formatting with clang-format
       uses: DoozyX/clang-format-lint-action@v0.5

--- a/.github/workflows/CI-lint.yml
+++ b/.github/workflows/CI-lint.yml
@@ -1,4 +1,4 @@
-name: Build and test - Linux
+name: Formatting and linting
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  BUILD_TYPE: Debug
+  BUILD_TYPE: Release
   DEPS_DIR: /home/runner/work/EchoConnect/dependencies
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
         key: ${{ runner.os }}-dependencies
 
     - name: Install PulseAudio, Doxygen
-      run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz
+      run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
 
     - name: Install QT
       uses: jurplel/install-qt-action@v2
@@ -35,6 +35,14 @@ jobs:
         dir: ${{ env.DEPS_DIR }}
         version: 5.12.7
         cached: ${{ steps.cache-deps.outputs.cache-hit }}
+
+    - name: Check code formatting with clang-format
+      uses: DoozyX/clang-format-lint-action@v0.5
+      with:
+        source: './libecho'
+        exclude: './libecho/external'
+        extensions: 'h,cpp,cc'
+        clangFormatVersion: 9
 
     - name: Create build folder
       run: cmake -E make_directory ${{ github.workspace }}/build
@@ -44,12 +52,6 @@ jobs:
       working-directory: ${{ github.workspace }}/build
       run: cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
-    - name: Build
-      working-directory: ${{ github.workspace }}/build
+    - name: Check with clang-tidy
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE
-
-    - name: Run tests
-      working-directory: ${{ github.workspace }}/build
-      shell: bash
-      run: GTEST_COLOR=1 ctest -V CTEST_OUTPUT_ON_FAILURE=TRUE
+      run: ${{ github.workspace }}/tools/clang-tidy.sh

--- a/.github/workflows/CI-lint.yml
+++ b/.github/workflows/CI-lint.yml
@@ -26,15 +26,15 @@ jobs:
         path: ${{ env.DEPS_DIR }}
         key: ${{ runner.os }}-dependencies
 
-    - name: Install PulseAudio, Doxygen
-      run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
-
     - name: Install QT
       uses: jurplel/install-qt-action@v2
       with:
         dir: ${{ env.DEPS_DIR }}
         version: 5.12.7
         cached: ${{ steps.cache-deps.outputs.cache-hit }}
+
+    - name: Install PulseAudio, Doxygen
+        run: sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
 
     - name: Check code formatting with clang-format
       uses: DoozyX/clang-format-lint-action@v0.5

--- a/.github/workflows/CI-linux.yml
+++ b/.github/workflows/CI-linux.yml
@@ -26,15 +26,15 @@ jobs:
         path: ${{ env.DEPS_DIR }}
         key: ${{ runner.os }}-dependencies
 
-    - name: Install PulseAudio, Doxygen
-      run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz
-
     - name: Install QT
       uses: jurplel/install-qt-action@v2
       with:
         dir: ${{ env.DEPS_DIR }}
         version: 5.12.7
         cached: ${{ steps.cache-deps.outputs.cache-hit }}
+
+    - name: Install PulseAudio, Doxygen
+      run: sudo apt-get install libpulse-dev doxygen graphviz
 
     - name: Create build folder
       run: cmake -E make_directory ${{ github.workspace }}/build

--- a/.github/workflows/CI-macos.yml
+++ b/.github/workflows/CI-macos.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI Linux
+name: CI MacOS
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -36,8 +36,8 @@ jobs:
     #    path: ${{ env.DEPS_DIR }}
     #    key: ${{ runner.os }}-dependencies
 
-    - name: Install PulseAudio, Doxygen
-      run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
+    #- name: Install PulseAudio, Doxygen
+    #  run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
 
     - name: Install QT
       uses: jurplel/install-qt-action@v2

--- a/.github/workflows/CI-macos.yml
+++ b/.github/workflows/CI-macos.yml
@@ -1,9 +1,4 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI MacOS
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+name: Build and test - MacOS
 
 on:
   push:
@@ -12,89 +7,46 @@ on:
     branches: [ master ]
 
 env:
-  BUILD_TYPE: Release
-  DEPS_DIR: /home/runner/work/EchoConnect/dependencies
+  BUILD_TYPE: Debug
+  DEPS_DIR: ${{ github.workspace }}/../dependencies
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: macos-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
       with:
         submodules: true
 
-    #- name: Cache dependencies
-    #  id: cache-deps
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: ${{ env.DEPS_DIR }}
-    #    key: ${{ runner.os }}-dependencies
-
-    #- name: Install PulseAudio, Doxygen
-    #  run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v1
+      with:
+        path: ${{ env.DEPS_DIR }}
+        key: ${{ runner.os }}-dependencies
 
     - name: Install QT
       uses: jurplel/install-qt-action@v2
       with:
         dir: ${{ env.DEPS_DIR }}
         version: 5.12.7
-    #    cached: ${{ steps.cache-deps.outputs.cache-hit }}
-
-    - name: Download and build GoogleTest
-    #  if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        git clone https://github.com/google/googletest.git
-        cd googletest
-        mkdir build && cd build
-        cmake .. -DBUILD_SHARED_LIBS=ON -DINSTALL_GTEST=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr
-        make -j8
-      working-directory: ${{ env.DEPS_DIR }}
-
-    - name: Install GoogleTest
-      run: |
-        cd googletest/build
-        sudo make install
-        sudo ldconfig
-      working-directory: ${{ env.DEPS_DIR }}
-
-    - name: Check code formatting with clang-format
-      uses: DoozyX/clang-format-lint-action@v0.5
-      with:
-        source: './libecho'
-        exclude: './libecho/external'
-        extensions: 'h,cpp,cc'
-        clangFormatVersion: 9
+        cached: ${{ steps.cache-deps.outputs.cache-hit }}
 
     - name: Create build folder
       run: cmake -E make_directory ${{ github.workspace }}/build
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
       shell: bash
       working-directory: ${{ github.workspace }}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-
-    - name: Check with clang-tidy
-      shell: bash
-      run: ${{ github.workspace }}/tools/clang-tidy.sh
 
     - name: Build
       working-directory: ${{ github.workspace }}/build
       shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
     - name: Run tests
       working-directory: ${{ github.workspace }}/build
       shell: bash
-      run: GTEST_COLOR=1 make test CTEST_OUTPUT_ON_FAILURE=TRUE
+      run: GTEST_COLOR=1 ctest -V CTEST_OUTPUT_ON_FAILURE=TRUE

--- a/.github/workflows/CI-macos.yml
+++ b/.github/workflows/CI-macos.yml
@@ -1,0 +1,100 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI Linux
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  BUILD_TYPE: Release
+  DEPS_DIR: /home/runner/work/EchoConnect/dependencies
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    #- name: Cache dependencies
+    #  id: cache-deps
+    #  uses: actions/cache@v1
+    #  with:
+    #    path: ${{ env.DEPS_DIR }}
+    #    key: ${{ runner.os }}-dependencies
+
+    - name: Install PulseAudio, Doxygen
+      run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
+
+    - name: Install QT
+      uses: jurplel/install-qt-action@v2
+      with:
+        dir: ${{ env.DEPS_DIR }}
+        version: 5.12.7
+    #    cached: ${{ steps.cache-deps.outputs.cache-hit }}
+
+    - name: Download and build GoogleTest
+    #  if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+        git clone https://github.com/google/googletest.git
+        cd googletest
+        mkdir build && cd build
+        cmake .. -DBUILD_SHARED_LIBS=ON -DINSTALL_GTEST=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr
+        make -j8
+      working-directory: ${{ env.DEPS_DIR }}
+
+    - name: Install GoogleTest
+      run: |
+        cd googletest/build
+        sudo make install
+        sudo ldconfig
+      working-directory: ${{ env.DEPS_DIR }}
+
+    - name: Check code formatting with clang-format
+      uses: DoozyX/clang-format-lint-action@v0.5
+      with:
+        source: './libecho'
+        exclude: './libecho/external'
+        extensions: 'h,cpp,cc'
+        clangFormatVersion: 9
+
+    - name: Create build folder
+      run: cmake -E make_directory ${{ github.workspace }}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{ github.workspace }}/build
+      # Note the current convention is to use the -S and -B options here to specify source
+      # and build directories, but this is only available with CMake 3.13 and higher.
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Check with clang-tidy
+      shell: bash
+      run: ${{ github.workspace }}/tools/clang-tidy.sh
+
+    - name: Build
+      working-directory: ${{ github.workspace }}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+
+    - name: Run tests
+      working-directory: ${{ github.workspace }}/build
+      shell: bash
+      run: GTEST_COLOR=1 make test CTEST_OUTPUT_ON_FAILURE=TRUE

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -1,4 +1,4 @@
-name: Build and test - Windows
+name: Build - Windows
 
 on:
   push:

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -1,9 +1,4 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI Windows
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+name: Build and test - Windows
 
 on:
   push:
@@ -12,89 +7,52 @@ on:
     branches: [ master ]
 
 env:
-  BUILD_TYPE: Release
-  DEPS_DIR: /home/runner/work/EchoConnect/dependencies
+  BUILD_TYPE: Debug
+  DEPS_DIR: ${{ github.workspace }}/../dependencies
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: windows-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
       with:
         submodules: true
 
-    #- name: Cache dependencies
-    #  id: cache-deps
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: ${{ env.DEPS_DIR }}
-    #    key: ${{ runner.os }}-dependencies
-
-    #- name: Install PulseAudio, Doxygen
-    #  run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v1
+      with:
+        path: ${{ env.DEPS_DIR }}
+        key: ${{ runner.os }}-dependencies
 
     - name: Install QT
       uses: jurplel/install-qt-action@v2
       with:
         dir: ${{ env.DEPS_DIR }}
         version: 5.12.7
-    #    cached: ${{ steps.cache-deps.outputs.cache-hit }}
-
-    - name: Download and build GoogleTest
-    #  if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        git clone https://github.com/google/googletest.git
-        cd googletest
-        mkdir build && cd build
-        cmake .. -DBUILD_SHARED_LIBS=ON -DINSTALL_GTEST=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr
-        make -j8
-      working-directory: ${{ env.DEPS_DIR }}
-
-    - name: Install GoogleTest
-      run: |
-        cd googletest/build
-        sudo make install
-        sudo ldconfig
-      working-directory: ${{ env.DEPS_DIR }}
-
-    - name: Check code formatting with clang-format
-      uses: DoozyX/clang-format-lint-action@v0.5
-      with:
-        source: './libecho'
-        exclude: './libecho/external'
-        extensions: 'h,cpp,cc'
-        clangFormatVersion: 9
+        cached: ${{ steps.cache-deps.outputs.cache-hit }}
 
     - name: Create build folder
       run: cmake -E make_directory ${{ github.workspace }}/build
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
       shell: bash
       working-directory: ${{ github.workspace }}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-
-    - name: Check with clang-tidy
-      shell: bash
-      run: ${{ github.workspace }}/tools/clang-tidy.sh
+      run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
     - name: Build
       working-directory: ${{ github.workspace }}/build
       shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
-    - name: Run tests
+    - name: Copy GTest DLL to tests folder (temporary workaround, hopefully)
       working-directory: ${{ github.workspace }}/build
       shell: bash
-      run: GTEST_COLOR=1 make test CTEST_OUTPUT_ON_FAILURE=TRUE
+      run: cp D:/a/EchoConnect/EchoConnect/build/bin/Debug/gtestd.dll ./libecho/tests/Debug/
+
+    #- name: Run tests
+    #  working-directory: ${{ github.workspace }}/build
+    #  shell: bash
+    #  #run: ctest -C Debug -VV --output-on-failure
+    #  run: ls ./libecho/tests/Debug/ && ./libecho/tests/Debug/libecho_test.exe

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -1,0 +1,100 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI Linux
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  BUILD_TYPE: Release
+  DEPS_DIR: /home/runner/work/EchoConnect/dependencies
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    #- name: Cache dependencies
+    #  id: cache-deps
+    #  uses: actions/cache@v1
+    #  with:
+    #    path: ${{ env.DEPS_DIR }}
+    #    key: ${{ runner.os }}-dependencies
+
+    - name: Install PulseAudio, Doxygen
+      run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
+
+    - name: Install QT
+      uses: jurplel/install-qt-action@v2
+      with:
+        dir: ${{ env.DEPS_DIR }}
+        version: 5.12.7
+    #    cached: ${{ steps.cache-deps.outputs.cache-hit }}
+
+    - name: Download and build GoogleTest
+    #  if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+        git clone https://github.com/google/googletest.git
+        cd googletest
+        mkdir build && cd build
+        cmake .. -DBUILD_SHARED_LIBS=ON -DINSTALL_GTEST=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr
+        make -j8
+      working-directory: ${{ env.DEPS_DIR }}
+
+    - name: Install GoogleTest
+      run: |
+        cd googletest/build
+        sudo make install
+        sudo ldconfig
+      working-directory: ${{ env.DEPS_DIR }}
+
+    - name: Check code formatting with clang-format
+      uses: DoozyX/clang-format-lint-action@v0.5
+      with:
+        source: './libecho'
+        exclude: './libecho/external'
+        extensions: 'h,cpp,cc'
+        clangFormatVersion: 9
+
+    - name: Create build folder
+      run: cmake -E make_directory ${{ github.workspace }}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{ github.workspace }}/build
+      # Note the current convention is to use the -S and -B options here to specify source
+      # and build directories, but this is only available with CMake 3.13 and higher.
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake ${{ github.workspace }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Check with clang-tidy
+      shell: bash
+      run: ${{ github.workspace }}/tools/clang-tidy.sh
+
+    - name: Build
+      working-directory: ${{ github.workspace }}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+
+    - name: Run tests
+      working-directory: ${{ github.workspace }}/build
+      shell: bash
+      run: GTEST_COLOR=1 make test CTEST_OUTPUT_ON_FAILURE=TRUE

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI Linux
+name: CI Windows
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -36,8 +36,8 @@ jobs:
     #    path: ${{ env.DEPS_DIR }}
     #    key: ${{ runner.os }}-dependencies
 
-    - name: Install PulseAudio, Doxygen
-      run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
+    #- name: Install PulseAudio, Doxygen
+    #  run: sudo apt update && sudo apt-get install libpulse-dev doxygen graphviz clang-tidy-9
 
     - name: Install QT
       uses: jurplel/install-qt-action@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,16 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.11.0)
 
-SET(CMAKE_C_COMPILER clang)
-SET(CMAKE_CXX_COMPILER clang++)
 SET(CMAKE_CXX_STANDARD 17)
+SET(BUILD_SHARED_LIBS ON)
 
 project(EchoConnect VERSION 1)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-strict-aliasing")
+if (MSVC)
+    add_compile_options(/W3)
+else()
+    add_compile_options(-Wall -Wextra -Werror -fno-strict-aliasing)
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(EchoConnect VERSION 1)
 if (MSVC)
     add_compile_options(/W3)
 else()
-    add_compile_options(-Wall -Wextra -Werror -fno-strict-aliasing)
+    add_compile_options(-Wall -Wextra -fno-strict-aliasing)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/libecho/CMakeLists.txt
+++ b/libecho/CMakeLists.txt
@@ -1,8 +1,6 @@
 project(libecho VERSION 0.1)
 
-
 find_package(Qt5 COMPONENTS Multimedia REQUIRED)
-
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -10,7 +8,6 @@ set(CMAKE_AUTOUIC ON)
 if (CMAKE_VERSION VERSION_LESS "3.7.0")
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif ()
-
 
 set(SRC_DIR "src" CACHE PATH "Source files path")
 set(API_DIR "include" CACHE PATH "Public API files path")
@@ -47,11 +44,17 @@ set_target_properties(echo
         PROPERTIES
         VERSION ${PROJECT_VERSION} SOVERSION 0
         PUBLIC_HEADER "${API_FILES}")
+set_target_properties(echo PROPERTIES ENABLE_EXPORTS 1)
+set_target_properties(echo PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+
 
 target_include_directories(echo PRIVATE ${SRC_DIR})
 target_include_directories(echo PRIVATE external/CRCpp/inc)
 
 target_link_libraries(echo Qt5::Multimedia)
+if(WIN32)
+    target_link_libraries(echo ws2_32)
+endif()
 
 
 add_subdirectory(tests)

--- a/libecho/examples/RawConnection/main.cc
+++ b/libecho/examples/RawConnection/main.cc
@@ -1,13 +1,17 @@
 //#include "Echo.h"
-
+#define _GLIBCXX_USE_C99 1
 #include <Echo.h>
-#include <cstring>
-#include <fstream>
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
-void printHelp(std::string name) {
+long to_long(const std::string &s) {
+    return strtol(s.c_str(), NULL, 10);
+}
+
+void printHelp(const std::string &name) {
     std::cout << "Usage: " << name << " [-freq low,high] [-win num] [-magLim num] send (data_bytes))\n";
-    std::cout << "Usage: " << name << " [-freq low,high] [-win num] [-magLim num] receive bytes_number\n";
+    std::cout << "Usage: " << name << " [-freq low,high] [-win num] [-magLim num] receive bytes_number\n\n\n";
     std::cout << "-freq: Set frequency of 0 bit (low) and 1 bit (high)\n";
     std::cout
         << "-win: Set window size (time in which 1 bit will be transfered). Higher - less errors, slowe transmition\n";
@@ -21,10 +25,10 @@ void printHelp(std::string name) {
 int main(int argc, char *argv[]) {
     Echo::initEcho(argc, argv);
 
-    int freq1 = 14000;
-    int freq2 = 15000;
-    int winsize = 50;
-    int magLim = 80;
+    long freq1 = 14000;
+    long freq2 = 15000;
+    long winsize = 50;
+    long magLim = 80;
 
     std::string name = argv[0];
     argv++;
@@ -39,21 +43,21 @@ int main(int argc, char *argv[]) {
         arg.erase(0, arg.find(',') + 1);
         std::string sfreq2 = arg.substr(0, arg.find(','));
 
-        freq1 = std::stoi(sfreq1);
-        freq2 = std::stoi(sfreq2);
+        freq1 = to_long(sfreq1);
+        freq2 = to_long(sfreq2);
 
         argv += 2;
         argc -= 2;
     }
 
     if (argc > 1 && argv[0] == std::string("-win")) {
-        winsize = std::stoi(argv[1]);
+        winsize = to_long(argv[1]);
         argv += 2;
         argc -= 2;
     }
 
     if (argc > 1 && argv[0] == std::string("-magLim")) {
-        magLim = std::stoi(argv[1]);
+        magLim = to_long(argv[1]);
         argv += 2;
         argc -= 2;
     }
@@ -69,11 +73,11 @@ int main(int argc, char *argv[]) {
         if (argc == 0) {
             printHelp(name);
         }
-        int bytes = std::stoi(argv[0]);
+        int bytes = to_long(argv[0]);
         argv++;
         argc--;
 
-        printf("Receiving %d bytes. Low frequency: %d, high frequency: %d, window size: %d, mag limit: %d\n", bytes,
+        printf("Receiving %d bytes. Low frequency: %ld, high frequency: %ld, window size: %ld, mag limit: %ld\n", bytes,
                freq1, freq2, winsize, magLim);
         auto connection = EchoRawConnection::getBitEchoRawConnection(winsize, freq1, freq2, freq1, freq2, 0, magLim);
         auto *buf = new uint8_t[bytes];
@@ -91,9 +95,9 @@ int main(int argc, char *argv[]) {
             printHelp(name);
         }
 
-        size_t length = strlen(argv[0]);
+        size_t length = std::string(argv[0]).length();
         std::vector<uint8_t> data(argv[0], argv[0] + length);
-        printf("Sending %zu bytes. Low frequency: %d, high frequency: %d, window size: %d, mag limit: %d\n", length,
+        printf("Sending %zu bytes. Low frequency: %ld, high frequency: %ld, window size: %ld, mag limit: %ld\n", length,
                freq1, freq2, winsize, magLim);
         auto connection = EchoRawConnection::getBitEchoRawConnection(winsize, freq1, freq2, freq1, freq2, 0, magLim);
         connection->sendBlocking(data);

--- a/libecho/src/AudioOutput.cc
+++ b/libecho/src/AudioOutput.cc
@@ -16,7 +16,7 @@ void AudioOutput::enqueueData(const char *data, int length) {
 }
 
 void AudioOutput::tryWriteData() {
-    size_t bytesToWrite = std::min(qStream->bytesFree(), buffer.size());
+    int bytesToWrite = std::min(qStream->bytesFree(), buffer.size());
     if (bytesToWrite == 0) {
         return;
     }

--- a/libecho/src/AudioStream.h
+++ b/libecho/src/AudioStream.h
@@ -185,10 +185,9 @@ public:
      * @return  Struct with current informations about stream.
      */
     AudioStreamInfo getStreamInfo() {
-        return {.bufferSize = qStream->bufferSize(),
-                .notifyInterval = qStream->notifyInterval(),
-                .periodSize = qStream->periodSize(),
-                .volume = qStream->volume()};
+        AudioStreamInfo info{qStream->bufferSize(), qStream->notifyInterval(), qStream->periodSize(),
+                             qStream->volume()};
+        return info;
     }
 
     /**

--- a/libecho/src/BitReceiver.h
+++ b/libecho/src/BitReceiver.h
@@ -13,14 +13,14 @@ public:
     int receiveFirst(uint8_t *buffer, int size) override;
     int receive(uint8_t *buffer, int size) override;
     void skip();
-    long getLoFrequency();
-    long getHiFrequency();
+    [[nodiscard]] long getLoFrequency() const;
+    [[nodiscard]] long getHiFrequency() const;
     void setLoFrequency(int freq);
     void setHiFrequency(int freq);
 
 private:
     void readSamples(int16_t *buffer, int len);
-    int stepShift(const double *buffer, int size);
+    int stepShift(const double *buffer, int size) const;
     int decodeBit(int16_t *windowBuffer);
     int receiveFirstTwoBits();
     void receiveBits(std::vector<bool> &vec, int offset);

--- a/libecho/src/BitReceiver.h
+++ b/libecho/src/BitReceiver.h
@@ -36,7 +36,7 @@ private:
 
     double lo_ratio = 0;
     double hi_ratio = 0;
-    [[ maybe_unused ]] int left_lim = 0;
+    int left_lim = 0;
     int right_lim = 0;
 };
 

--- a/libecho/src/BitReceiver.h
+++ b/libecho/src/BitReceiver.h
@@ -36,7 +36,7 @@ private:
 
     double lo_ratio = 0;
     double hi_ratio = 0;
-    int left_lim = 0;
+    [[ maybe_unused ]] int left_lim = 0;
     int right_lim = 0;
 };
 

--- a/libecho/src/BitReceiverv2.cc
+++ b/libecho/src/BitReceiverv2.cc
@@ -1,6 +1,8 @@
 #include "BitReceiverv2.h"
 #include <cmath>
-
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 static const int SAMPLE_RATE = 44100;
 static const int SAMPLE_SIZE = 16;
 static const int CHANNEL_COUNT = 1;

--- a/libecho/src/BitSender.cc
+++ b/libecho/src/BitSender.cc
@@ -2,7 +2,9 @@
 #include "HammingCode.h"
 
 #include <cmath>
-#include <iostream>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 const QAudioFormat::Endian OUTPUT_BYTEORDER = QAudioFormat::LittleEndian;
 const int OUTPUT_CHANNEL_COUNT = 1;

--- a/libecho/src/BitSender.h
+++ b/libecho/src/BitSender.h
@@ -28,14 +28,14 @@ public:
     /**
      * @brief loFreq member getter.
      */
-    int getLoFreq() {
+    [[nodiscard]] int getLoFreq() const {
         return loFreq;
     }
 
     /**
      * @brief hiFreq member getter.
      */
-    int getHiFreq() {
+    [[nodiscard]] int getHiFreq() const {
         return hiFreq;
     }
 

--- a/libecho/src/BitSenderv2.cc
+++ b/libecho/src/BitSenderv2.cc
@@ -1,6 +1,9 @@
 #include "BitSenderv2.h"
 #include <cmath>
 #include <iostream>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 static const double RISE = 0.1;
 static const double FALL = 0.1;

--- a/libecho/src/BitSenderv2.cc
+++ b/libecho/src/BitSenderv2.cc
@@ -37,10 +37,9 @@ void BitSenderv2::start() {
 void BitSenderv2::send(uint8_t *buffer, int size) {
     auto *out = new int16_t[size * win_size * 8];
     int16_t *out_end = out;
-    uint8_t byte;
 
     for (int i = 0; i < size; i++) {
-        byte = buffer[i];
+        uint8_t byte = buffer[i];
         for (int j = 0; j < 8; j++) {
             write_bit(out_end, byte & 1);
             out_end += win_size;

--- a/libecho/src/ISender.h
+++ b/libecho/src/ISender.h
@@ -41,7 +41,7 @@ public:
     /**
      * @brief winSize member getter.
      */
-    int getWindowSize() {
+    [[nodiscard]] int getWindowSize() const {
         return winSize;
     }
 

--- a/libecho/src/Packet.cc
+++ b/libecho/src/Packet.cc
@@ -75,15 +75,15 @@ std::vector<uint8_t> Packet::toBytes() {
     return bytes;
 }
 
-bool Packet::isSet(Flag f) {
+bool Packet::isSet(Flag f) const {
     return (flags & f) != 0;
 }
 
-uint16_t Packet::getSize() {
+uint16_t Packet::getSize() const {
     return size;
 }
 
-uint16_t Packet::getNumber() {
+uint16_t Packet::getNumber() const {
     return number;
 }
 
@@ -106,19 +106,18 @@ void Packet::unsetFlag(Flag f) {
     updateCRC();
 }
 
-void Packet::setData(const std::vector<uint8_t> &data) {
+void Packet::setData(const std::vector<uint8_t> &newData) {
     if (data.size() > MAX_DATA_SIZE) {
         throw Packet::OversizedData();
     }
 
-    this->data = data;
+    this->data = newData;
     size = data.size();
     updateCRC();
 }
 
 uint32_t Packet::calculateCRC() {
-    uint32_t result;
-    result = CRC::Calculate(&flags, sizeof(flags), CRC::CRC_32());
+    uint32_t result = CRC::Calculate(&flags, sizeof(flags), CRC::CRC_32());
     result = CRC::Calculate(&size, sizeof(size), CRC::CRC_32(), result);
     result = CRC::Calculate(&number, sizeof(number), CRC::CRC_32(), result);
     result = CRC::Calculate(data.data(), data.size(), CRC::CRC_32(), result);

--- a/libecho/src/Packet.h
+++ b/libecho/src/Packet.h
@@ -10,7 +10,7 @@ static constexpr size_t HEADER_SIZE = 6;                     /**< Size of packet
 static constexpr size_t CRC_SIZE = 4;                        /**< Size of control sum of packet in bytes. */
 static constexpr size_t FRAME_SIZE = HEADER_SIZE + CRC_SIZE; /**< Size of packet frame in bytes. */
 static constexpr size_t MAX_DATA_SIZE =
-    std::numeric_limits<uint16_t>::max(); /**< Maximum size of data send in packet in bytes. */
+    (std::numeric_limits<uint16_t>::max)(); /**< Maximum size of data send in packet in bytes. */
 
 /**
  * @brief Enum representing flags with which packet may be marked.
@@ -76,17 +76,17 @@ public:
      * @param f Checked flag.
      * @return  Returns @p true if given flag is set, otherwise @p false.
      */
-    bool isSet(Flag f);
+    [[nodiscard]] bool isSet(Flag f) const;
 
     /**
      * @brief Returns size of packet encapsulated data.
      */
-    uint16_t getSize();
+    [[nodiscard]] uint16_t getSize() const;
 
     /**
      * @brief Returns sequential number of packet.
      */
-    uint16_t getNumber();
+    [[nodiscard]] uint16_t getNumber() const;
 
     /**
      * @brief Returns data encapsulated in packet.

--- a/libecho/tests/CMakeLists.txt
+++ b/libecho/tests/CMakeLists.txt
@@ -1,8 +1,27 @@
 set(EXEC_NAME libecho_test)
 set(CMAKE_EXPORT_COMPILE_COMMANDS OFF)
 
-find_package(GTest REQUIRED)
-include_directories(${GTEST_INCLUDE_DIRS})
+set(GTEST_VERSION 1.10.0 CACHE STRING "Google test version")
+################################
+# GTest
+################################
+find_package(GTest)
+if(GTest_FOUND)
+    include_directories(${GTEST_INCLUDE_DIRS})
+else()
+    include(FetchContent)
+    FetchContent_Declare(googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_TAG release-${GTEST_VERSION})
+
+    FetchContent_GetProperties(googletest)
+    if(NOT googletest_POPULATED)
+        FetchContent_Populate(googletest)
+        add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+    endif()
+
+    FetchContent_MakeAvailable(googletest)
+endif()
 
 set(TEST_FILES
         main.cc
@@ -15,7 +34,8 @@ include_directories("../external/CRCpp/inc")
 add_executable(${EXEC_NAME} ${TEST_FILES})
 add_executable(sendrecv sendrecv.cpp)
 
+target_link_libraries(${EXEC_NAME} echo gtest gtest_main)
+target_link_libraries(sendrecv echo)
+
 add_test(NAME ${EXEC_NAME} COMMAND ${EXEC_NAME})
 
-target_link_libraries(${EXEC_NAME} echo ${GTEST_BOTH_LIBRARIES})
-target_link_libraries(sendrecv echo)

--- a/libecho/tests/dft.cpp
+++ b/libecho/tests/dft.cpp
@@ -2,6 +2,9 @@
 
 #include "AudioInput.h"
 #include "Echo.h"
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 double mag(double re, double im) {
     return sqrt(re * re + im * im);

--- a/libecho/tests/getlim.cpp
+++ b/libecho/tests/getlim.cpp
@@ -1,6 +1,9 @@
 #include <math.h>
 #include "AudioInput.h"
 #include "Echo.h"
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 #define WINDOWS 1000
 

--- a/libecho/tests/info.cpp
+++ b/libecho/tests/info.cpp
@@ -1,6 +1,9 @@
 #include <math.h>
 #include "AudioInput.h"
 #include "Echo.h"
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 #define WINDOWS 1000
 

--- a/libecho/tests/packet_tests.cc
+++ b/libecho/tests/packet_tests.cc
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <cstdint>
-#include <string>
 #include <vector>
 
 #ifdef _WIN32
@@ -13,7 +12,7 @@
 #include "CRC.h"
 #include "Packet.h"
 
-uint16_t SIZE = 3, NUM = 2137;
+uint16_t MESSAGE_SIZE = 3, NUM = 2137;
 
 const std::vector<Flag> SET_FLAGS{Flag::ACK1, Flag::DMD, Flag::LPC}, UNSET_FLAGS{Flag::SYN, Flag::FIN, Flag::RST};
 
@@ -35,7 +34,7 @@ std::vector<uint8_t> calc_crc32(std::vector<uint8_t> v) {
 
 TEST(tests_packet, test_loadHeaderFromBytes) {
     auto p = Packet::loadHeaderFromBytes(header);
-    ASSERT_EQ(SIZE, p.getSize());
+    ASSERT_EQ(MESSAGE_SIZE, p.getSize());
     ASSERT_EQ(NUM, p.getNumber());
 
     for (auto f : SET_FLAGS) {
@@ -51,13 +50,12 @@ TEST(tests_packet, test_incorrect_loadHeaderFromBytes) {
 }
 
 TEST(tests_packet, test_loadDataFromBytes) {
-    uint8_t t[] = {13, 4, 55};
     auto p = Packet::loadHeaderFromBytes(header);
     p.loadDataFromBytes(data);
-    auto data = p.getData();
-    ASSERT_EQ(data.size(), 3);
+    auto localData = p.getData();
+    ASSERT_EQ(localData.size(), 3);
     for (size_t i = 0; i < 3; i++) {
-        ASSERT_EQ(t[i], data[i]);
+        ASSERT_EQ(data[i], localData[i]);
     }
 }
 
@@ -258,10 +256,10 @@ TEST(tests_packet_builder, test_setNumber) {
 
     ASSERT_EQ(p.getNumber(), NUM);
 
-    pb.setNumber(SIZE);
+    pb.setNumber(MESSAGE_SIZE);
     p = pb.getPacket();
 
-    ASSERT_EQ(p.getNumber(), SIZE);
+    ASSERT_EQ(p.getNumber(), MESSAGE_SIZE);
 }
 
 TEST(tests_packet_builder, test_getPacket) {
@@ -274,8 +272,8 @@ TEST(tests_packet_builder, test_getPacket) {
     auto d = p.getData();
 
     ASSERT_EQ(p.getNumber(), NUM);
-    ASSERT_EQ(p.getSize(), SIZE);
-    for (size_t i = 0; i < SIZE; i++) {
+    ASSERT_EQ(p.getSize(), MESSAGE_SIZE);
+    for (size_t i = 0; i < MESSAGE_SIZE; i++) {
         ASSERT_EQ(d[i], data[i]);
     }
 


### PR DESCRIPTION
- Uproszczone skrypty do CI - budowanie googletest przeniesione do cmake, tak więc nie jest już wymagany, będzie automatycznie pobrany i zbudowany przy kompilacji.
- 4 workflowy - windows, linux, max, lint (na linuxie). Windows póki co bez tesów, z powodu problemów z dllkami.
- Nieco refactoringu skryptów