### PR TITLE
Packet external documentation, README.md as main page in documentation

### DIFF
--- a/libecho/docs/Doxyfile.in
+++ b/libecho/docs/Doxyfile.in
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/../src/ @CMAKE_CURRENT_SOURCE_DIR@/../docs @CMAKE_CURRENT_SOURCE_DIR@/../include
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/../../README.md @CMAKE_CURRENT_SOURCE_DIR@/../src/ @CMAKE_CURRENT_SOURCE_DIR@/../docs @CMAKE_CURRENT_SOURCE_DIR@/../include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1026,7 +1026,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = @CMAKE_CURRENT_SOURCE_DIR@/../../README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -1575,7 +1575,7 @@ FORMULA_MACROFILE      =
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:

--- a/libecho/docs/packet.md
+++ b/libecho/docs/packet.md
@@ -53,7 +53,7 @@ Data encapsulated in packet. Its size is limited to \f$2^{16}-11\f$ bytes becaus
 
 #### Control sum
 
-Packet checksum, to be more specific **CRC32** of other other packet components. Whenever transmitted packet is deserialized, if the control sum is invalid, the exception is raised. We are using [CRCpp](https://github.com/d-bahr/CRCpp/tree/51fbc35ef892e98abe91a51f7320749c929d72bd) library to calculate checksum.
+Packet checksum, to be more specific **CRC32** of all other packet components. Whenever transmitted packet is deserialized, if the control sum is invalid, the exception is raised. We are using [CRCpp](https://github.com/d-bahr/CRCpp/tree/51fbc35ef892e98abe91a51f7320749c929d72bd) library to calculate checksum.
 
 
 <br>

--- a/libecho/docs/packet.md
+++ b/libecho/docs/packet.md
@@ -4,9 +4,13 @@ We designed our own packet format to send data as sound in EchoConnect project.
 Packets are essential when implementing the protocol, allow to encapsulate data into rather small parts, each with its own checksum. Thanks to that when incorrect transmission happens, it is easier to detect that and ask for retransmission. No less important is that by setting particular flags we are able to indicate particular events to the receiver.
 
 
-- - -
+<br>
 
 ### Structure
+
+- - -
+
+Packets in serialized form are structured as below:
 
 | element | size |
 | :---: | :---: |
@@ -32,36 +36,40 @@ Existing flags:
 - **RST**: reset, used to break the connection brutally when something is not right.
 
 
-### Packet size
+#### Packet size
 
 Size of a packet (header + content) in bytes. As it is a 16 bit number, the maximum valid packet size is \f$2^{16}-1\f$ bytes.
 
 
-### Sequential number
+#### Sequential number
 
 Identifier of packet.
 
 
-### Data
+#### Data
 
 Data encapsulated in packet. Its size is limited to \f$2^{16}-11\f$ bytes because of existing packet size and need to reserve 10 bytes for packet frame.
 
 
-### Control sum
+#### Control sum
 
 Packet checksum, to be more specific **CRC32** of other other packet components. Whenever transmitted packet is deserialized, if the control sum is invalid, the exception is raised. We are using [CRCpp](https://github.com/d-bahr/CRCpp/tree/51fbc35ef892e98abe91a51f7320749c929d72bd) library to calculate checksum.
 
 
-- - -
+<br>
 
-## Notes
+### Notes
+
+- - -
 
 - We are supporting packet from object to bytes serialization as well as packet partial deserialization to object (in 3 phases - first header, then data and checksum at the end).
 - We are using network endianness when sending serialized bytes. Although it doesn't change anything for content data, as it is being kept as a series of single bytes. So that fact is important only when someone is trying to build or parse a packet on their own. In such case it is crucial to remember about converting header fields and checksum to right endianness (_actually, author had mass of debugging while implementing and writing tests for packets cause she forgot about that converting :P_).
 
 
-- - -
+<br>
 
-## Implementation
+### Implementation
+
+- - -
 
 Current packet declaration and definition is available to read in [Packet.h](https://github.com/Lorak-mmk/EchoConnect/blob/master/libecho/src/Packet.h) and [Packet.cc](https://github.com/Lorak-mmk/EchoConnect/blob/master/libecho/src/Packet.cc) files in [EchoConnect](https://github.com/Lorak-mmk/EchoConnect) project repository.

--- a/libecho/docs/packet.md
+++ b/libecho/docs/packet.md
@@ -1,0 +1,67 @@
+﻿# Packet
+
+We designed our own packet format to send data as sound in EchoConnect project.
+Packets are essential when implementing the protocol, allow to encapsulate data into rather small parts, each with its own checksum. Thanks to that when incorrect transmission happens, it is easier to detect that and ask for retransmission. No less important is that by setting particular flags we are able to indicate particular events to the receiver.
+
+
+- - -
+
+### Structure
+
+| element | size |
+| :---: | :---: |
+| **header ⬎** | 6 bytes |
+| flags | 2 bytes |
+| packet size | 2 bytes |
+| sequential number | 2 bytes |
+| **transmitted data** | up to \f$2^{16}-11\f$ bytes |
+| **frame check sequence ⬎** | 4 bytes |
+| control sum | 4 bytes |
+
+
+#### Flags
+
+As for now there is **7** flags defined, but we have space for at most **16** flags (assuming we keep current implementation) and new ones can be easily added.
+Existing flags:
+- **SYN** : synchronization, used in connection initialization between hosts, only first packet sent out by host should have that flag set.
+- **ACK1** : acknowledgement 1, used to confirm something, ex. creating a connection or that the packet was received coffectly.
+- **ACK2**: acknowledgement 2, used to confirm receiving of the packet with the flag ACK1.
+- **LPC**: last packet, informs that this is the last packet in a group of consecutive packets.
+- **DMD**: demand resend, used to inform that some received packets were invalid or lost and there is a need to resend them.
+- **FIN**: finish, used to inform that party is ending connection.
+- **RST**: reset, used to break the connection brutally when something is not right.
+
+
+### Packet size
+
+Size of a packet (header + content) in bytes. As it is a 16 bit number, the maximum valid packet size is \f$2^{16}-1\f$ bytes.
+
+
+### Sequential number
+
+Identifier of packet.
+
+
+### Data
+
+Data encapsulated in packet. Its size is limited to \f$2^{16}-11\f$ bytes because of existing packet size and need to reserve 10 bytes for packet frame.
+
+
+### Control sum
+
+Packet checksum, to be more specific **CRC32** of other other packet components. Whenever transmitted packet is deserialized, if the control sum is invalid, the exception is raised. We are using [CRCpp](https://github.com/d-bahr/CRCpp/tree/51fbc35ef892e98abe91a51f7320749c929d72bd) library to calculate checksum.
+
+
+- - -
+
+## Notes
+
+- We are supporting packet from object to bytes serialization as well as packet partial deserialization to object (in 3 phases - first header, then data and checksum at the end).
+- We are using network endianness when sending serialized bytes. Although it doesn't change anything for content data, as it is being kept as a series of single bytes. So that fact is important only when someone is trying to build or parse a packet on their own. In such case it is crucial to remember about converting header fields and checksum to right endianness (_actually, author had mass of debugging while implementing and writing tests for packets cause she forgot about that converting :P_).
+
+
+- - -
+
+## Implementation
+
+Current packet declaration and definition is available to read in [Packet.h](https://github.com/Lorak-mmk/EchoConnect/blob/master/libecho/src/Packet.h) and [Packet.cc](https://github.com/Lorak-mmk/EchoConnect/blob/master/libecho/src/Packet.cc) files in [EchoConnect](https://github.com/Lorak-mmk/EchoConnect) project repository.

--- a/libecho/docs/packet.md
+++ b/libecho/docs/packet.md
@@ -12,15 +12,15 @@ Packets are essential when implementing the protocol, allow to encapsulate data 
 
 Packets in serialized form are structured as below:
 
-| element | size |
+| element | size in bytes |
 | :---: | :---: |
-| **header ⬎** | 6 bytes |
-| flags | 2 bytes |
-| packet size | 2 bytes |
-| sequential number | 2 bytes |
-| **transmitted data** | up to \f$2^{16}-11\f$ bytes |
-| **frame check sequence ⬎** | 4 bytes |
-| control sum | 4 bytes |
+| **header ⬎** | 6 |
+| flags | 2 |
+| packet size | 2 |
+| sequential number | 2 |
+| **transmitted data** | up to \f$2^{16}-11\f$ |
+| **frame check sequence ⬎** | 4 |
+| control sum | 4 |
 
 
 #### Flags


### PR DESCRIPTION
- added out of code detailed documentation of packets used in library
- changed Doxygen config file to use repository README.md as main page in documentation